### PR TITLE
set version to 0.6.0 prior to tagging release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ os:
   - osx
 julia:
   - 1.0
+  - 1
   - nightly
+matrix:
+  fast_finish: true
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "Proj4"
 uuid = "9a7e659c-8ee8-5706-894e-f68f43bc57ea"
+version = "0.6.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
@@ -10,6 +11,6 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-BinaryProvider = "≥ 0.5.0"
-julia = "≥ 1.0.0"
-CEnum = "≥ 0.2.0"
+BinaryProvider = "0.5"
+CEnum = "0.2"
+julia = "1.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,17 @@
 environment:
   matrix:
   - julia_version: 1.0
+  - julia_version: 1
   - julia_version: nightly
 
 platform:
   - x86 # 32-bit
   - x64 # 64-bit
 
-# # Uncomment the following lines to allow failures on nightly julia
-# # (tests will run but not make your overall status red)
-# matrix:
-#   allow_failures:
-#   - julia_version: nightly
+matrix:
+  fast_finish: true
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:
@@ -34,9 +34,3 @@ build_script:
 test_script:
   - echo "%JL_TEST_SCRIPT%"
   - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
-
-# # Uncomment to support code coverage upload. Should only be enabled for packages
-# # which would have coverage gaps without running on Windows
-# on_success:
-#   - echo "%JL_CODECOV_SCRIPT%"
-#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"


### PR DESCRIPTION
Also set upper bounds on dependencies and update CI config.