### PR TITLE
try PROJ 7 binaries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 
 [compat]
 CEnum = "0.2"
-PROJ_jll = "6.2.1"
+PROJ_jll = "6.2.1, 7"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Reading the PROJ 7 breaking changes at https://proj.org/news.html#breaking-changes, it looks like none of them really apply to this package, meaning we could possibly do a non breaking release of this package that allows PROJ 7.

This would probably make migration to a new package based around the new API easier, if they can use the same binary, ref https://github.com/JuliaGeo/Proj4.jl/issues/26#issuecomment-622519649.

Locally on Windows this didn't pass yet due to an issue with the newly added libtiff dependency:

```
ERROR: LoadError: LoadError: InitError: could not load library "C:\Users\visser_mn\.julia\artifacts\f98adb5b4de5c29a8d77def412b792beaec6180b\bin\libtiff-5.dll"
The specified module could not be found.
Stacktrace:
 [1] dlopen(::String, ::UInt32; throw_error::Bool) at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\Libdl\src\Libdl.jl:109
 [2] dlopen at D:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.4\Libdl\src\Libdl.jl:109 [inlined] (repeats 2 times)
 [3] __init__() at C:\Users\visser_mn\.julia\packages\Libtiff_jll\0kDRi\src\wrappers\x86_64-w64-mingw32.jl:45
 [4] _include_from_serialized(::String, ::Array{Any,1}) at .\loading.jl:697
 [5] _require_search_from_serialized(::Base.PkgId, ::String) at .\loading.jl:781
 [6] _require(::Base.PkgId) at .\loading.jl:1006
 [7] require(::Base.PkgId) at .\loading.jl:927
 [8] require(::Module, ::Symbol) at .\loading.jl:922
 [9] include(::Module, ::String) at .\Base.jl:377
 [10] include(::String) at C:\Users\visser_mn\.julia\packages\PROJ_jll\ZeTfD\src\PROJ_jll.jl:1
 [11] top-level scope at C:\Users\visser_mn\.julia\packages\PROJ_jll\ZeTfD\src\PROJ_jll.jl:50
 [12] include(::Module, ::String) at .\Base.jl:377
 [13] top-level scope at none:2
 [14] eval at .\boot.jl:331 [inlined]
 [15] eval(::Expr) at .\client.jl:449
 [16] top-level scope at .\none:3
during initialization of module Libtiff_jll
```

But opening this PR as a draft to check the situation on other platforms.