### PR TITLE
CoordinateTransformations.jl interface through new API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 deps/build.log
 deps/deps.jl
 deps/usr
+
+/Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
+/docs/build/
+*.jl.*.cov
 *.jl.cov
 *.jl.mem
-deps/build.log
-deps/deps.jl
-deps/usr
-
 /Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,8 @@ PROJ_jll = "6.2.1, 7"
 julia = "1.3"
 
 [extras]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "StaticArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-CoordinateTransformations = "0.5"
+CoordinateTransformations = "0.5, 0.6"
 PROJ_jll = "6.2.1, 7"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ version = "0.7.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
+CoordinateTransformations = "0.5"
 PROJ_jll = "6.2.1, 7"
 julia = "1.3"
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ using Proj4
 
 wgs84 = Projection("+proj=longlat +datum=WGS84 +no_defs")
 utm56 = Projection("+proj=utm +zone=56 +south +datum=WGS84 +units=m +no_defs")
-
-transform(wgs84, utm56, [150 -27 0])
+transformation = CRS2CRS(wgs84, utm56) # transformation from WGS84 -> UTM56
+transformation([150 -27 0])
 # Should result in [202273.913 7010024.033 0.0]
+# alternatively (old API): transform using projections
+transform(wgs84, utm56, [150 -27 0])
 ```
 
 API documentation for the underlying C API may be found here:

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"

--- a/src/Proj4.jl
+++ b/src/Proj4.jl
@@ -33,6 +33,8 @@ include("proj_types.jl") # type definitions for proj objects
 include("proj_functions.jl") # user-facing proj functions
 include("coordinate_transformations.jl")
 
+export CRS2CRS, proj_coord
+
 "Get a global error string in human readable form"
 error_message() = _strerrno()
 

--- a/src/Proj4.jl
+++ b/src/Proj4.jl
@@ -1,7 +1,7 @@
 module Proj4
 
 using PROJ_jll
-using CEnum
+using CEnum, CoordinateTransformations
 
 export Projection, # proj_types.jl
        transform, transform!,  # proj_functions.jl
@@ -31,6 +31,7 @@ const has_geodesic_support = true
 
 include("proj_types.jl") # type definitions for proj objects
 include("proj_functions.jl") # user-facing proj functions
+include("coordinate_transformations.jl")
 
 "Get a global error string in human readable form"
 error_message() = _strerrno()

--- a/src/Proj4.jl
+++ b/src/Proj4.jl
@@ -31,7 +31,8 @@ const has_geodesic_support = true
 
 include("proj_types.jl") # type definitions for proj objects
 include("proj_functions.jl") # user-facing proj functions
-include("coordinate_transformations.jl")
+include("overloads.jl") # overloads for a more Julian API
+include("coordinate_transformations.jl") # CRS2CRS interface
 
 export CRS2CRS, proj_coord
 

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -5,10 +5,6 @@ end
 
 function CRS2CRS(source::String, target::String, direction::PJ_DIRECTION = PJ_FWD; area = C_NULL, normalize = true)
 
-    if direction == PJ_IDENT || source == direction
-        return IdentityTransformation()
-    end
-
     pj_init = proj_create_crs_to_crs(source, target, area)
 
     obj = if normalize
@@ -16,7 +12,7 @@ function CRS2CRS(source::String, target::String, direction::PJ_DIRECTION = PJ_FW
         proj_destroy(pj_init)
         CRS2CRS(pj_normalized, direction)
     else
-        CRS2CRS(pj_normalized, direction)
+        CRS2CRS(pj_init, direction)
     end
 
     finalizer(obj) do obj
@@ -51,7 +47,7 @@ end
 function CoordinateTransformations.transform_deriv(cs::CRS2CRS, x)
     coord = proj_coord(x...)
     factors = proj_factors(cs.rep, coord)
-    return [dx_dlam dx_dphi; dy_dlam dy_dphi]
+    return [factors.dx_dlam factors.dx_dphi; factors.dy_dlam factors.dy_dphi]
 end
 
 function (transformation::CRS2CRS)(x::T) where T

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -53,6 +53,19 @@ end
 
 Base.inv(cs::CRS2CRS) = CRS2CRS(cs.rep, inv(cs.direction))
 
+function Base.show(io::IO, ::MIME"text/plain", cs::CRS2CRS)
+    # info = proj_pj_info(cs.rep)
+    direction = if cs.direction == PJ_FWD
+        "Forward"
+    elseif cs.direction == PJ_INV
+        "Reverse"
+    else
+        "Identity"
+    end
+    println(io, "$(direction)-mode CRS2CRS:")
+    println(io, Proj4.proj_as_proj_string(cs.rep, Proj4.PJ_PROJ_4))
+end
+
 function Base.inv(dir::PJ_DIRECTION)
     return if dir == PJ_IDENT
         PJ_IDENT

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -69,7 +69,7 @@ function CoordinateTransformations.transform_deriv(cs::CRS2CRS, x)
     return [factors.dx_dlam factors.dx_dphi; factors.dy_dlam factors.dy_dphi]
 end
 
-function (transformation::CRS2CRS)(x::T) where T
+function (transformation::CRS2CRS)(x)
     coord = if length(x) == 2
         proj_coord(x[1], x[2],    0,    0)
     elseif length(x) == 3

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -3,13 +3,13 @@ mutable struct CRS2CRS <: CoordinateTransformations.Transformation
     direction::PJ_DIRECTION
 end
 
-function CRS2CRS(source::String, dest::String, direction::PJ_DIRECTION = PJ_FWD; area = C_NULL, normalize = true)
+function CRS2CRS(source::String, target::String, direction::PJ_DIRECTION = PJ_FWD; area = C_NULL, normalize = true)
 
     if direction == PJ_IDENT || source == direction
         return IdentityTransformation()
     end
 
-    pj_init = proj_create_crs_to_crs(source, dest, area)
+    pj_init = proj_create_crs_to_crs(source, target, area)
 
     obj = if normalize
         pj_normalized = proj_normalize_for_visualization(pj_init)
@@ -24,6 +24,16 @@ function CRS2CRS(source::String, dest::String, direction::PJ_DIRECTION = PJ_FWD;
     end
 
     return obj
+end
+
+function CRS2CRS(source::Projection, target::Projection, direction::PJ_DIRECTION = PJ_FWD; area = C_NULL, normalize = true)
+    return CRS2CRS(
+        sprint(print, source),
+        sprint(print, target),
+        direction;
+        area = area,
+        normalize = true
+    )
 end
 
 Base.inv(cs::CRS2CRS) = CRS2CRS(cs.rep, inv(cs.direction))

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -132,3 +132,4 @@ end
 # (these mostly just forward `cs -> cs.rep`)
 
 proj_as_wkt(cs::CRS2CRS, type::PJ_WKT_TYPE, ctx = C_NULL, options = C_NULL) = proj_as_wkt(cs.rep, type, ctx, options)
+proj_factors(cs::CRS2CRS, coord::PJ_COORD) = proj_factors(cs.rep, coord)

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -71,11 +71,11 @@ end
 
 function (transformation::CRS2CRS)(x)
     coord = if length(x) == 2
-        proj_coord(x[1], x[2],    0,    0)
+        PJ_COORD(x[1], x[2],    0,    0)
     elseif length(x) == 3
-        proj_coord(x[1], x[2], x[3],    0)
+        PJ_COORD(x[1], x[2], x[3],    0)
     elseif length(x) == 4
-        proj_coord(x[1], x[2], x[3], x[4])
+        PJ_COORD(x[1], x[2], x[3], x[4])
     else
         error("Input must have length 2, 3 or 4! Found $(length(x)).")
     end

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -1,3 +1,21 @@
+"""
+    CRS2CRS(source, target, [direction = PJ_FWD]; area = C_NULL, normalize = true)
+
+Constructs a coordinate system transformation from `source` to `target`.  The source and target CRS may be Strings or [`Projection`](@ref)s.
+
+CRS2CRS objects are callable, and transformations are performed by
+calling them on point-like types.  They also satisfy the
+[CoordinateTransformations.jl](https://github.com/JuliaGeometry/CoordinateTransformations.jl) interface.
+
+```julia
+# Construct a projection from lon-lat coordinates
+# to the Winkel Tripel projection
+cs = CRS2CRS("+proj=lonlat", "+proj=wintri")
+# construct a projectable coordinate
+a = proj_coord(0, 0)
+b = cs(a) # projected coordinate
+```
+"""
 mutable struct CRS2CRS <: CoordinateTransformations.Transformation
     rep::Ptr{Cvoid}
     direction::PJ_DIRECTION

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -67,12 +67,6 @@ function Base.inv(dir::PJ_DIRECTION)
 end
 Base.inv(cs::CRS2CRS) = CRS2CRS(cs.rep, inv(cs.direction))
 
-function CoordinateTransformations.transform_deriv(cs::CRS2CRS, x)
-    coord = proj_coord(x...)
-    factors = proj_factors(cs.rep, coord)
-    return [factors.dx_dlam factors.dx_dphi; factors.dy_dlam factors.dy_dphi]
-end
-
 function (transformation::CRS2CRS)(x)
     # if `x` is too long, this will throw
     # a methoderror (there are 0, 1, 2, 3, and 4-arg)

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -67,7 +67,7 @@ function Base.inv(dir::PJ_DIRECTION)
 end
 Base.inv(cs::CRS2CRS) = CRS2CRS(cs.rep, inv(cs.direction))
 
-function (transformation::CRS2CRS)(x)
+function (transformation::CRS2CRS)(x::T) where T
     # if `x` is too long, this will throw
     # a methoderror (there are 0, 1, 2, 3, and 4-arg)
     # versions of the PJ_COORD constructor.

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -1,0 +1,112 @@
+mutable struct CRS2CRS <: CoordinateTransformations.Transformation
+    rep::Ptr{Cvoid}
+    direction::PJ_DIRECTION
+end
+
+function CRS2CRS(source::Projection, dest::Projection, direction::PJ_DIRECTION = PJ_FWD; area = C_NULL, normalize = true)
+
+    if direction == PJ_IDENT || proj_is_equivalent_to(source.rep, dest.rep, PJ_COMP_EQUIVALENT) == 1
+        return IdentityTransformation()
+    end
+
+    pj_init = ccall(
+        (:proj_create_crs_to_crs_from_pj, PROJ_jll.libproj),
+        Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cchar}),
+        source.rep,  dest.rep,   area,       C_NULL
+    )
+
+    obj = if normalize
+        pj_normalized = proj_normalize_for_visualization(pj_init)
+        proj_destroy(pj_init)
+        CRS2CRS(pj_normalized, direction)
+    else
+        CRS2CRS(pj_normalized, direction)
+    end
+
+    finalizer(obj) do
+        proj_destroy(obj.rep)
+        _free(proj.rep)
+    end
+
+    return obj
+end
+
+
+function CRS2CRS(source::String, dest::String, direction::PJ_DIRECTION = PJ_FWD; area = C_NULL, normalize = true)
+
+    if direction == PJ_IDENT || source == direction
+        return IdentityTransformation()
+    end
+
+    pj_init = proj_create_crs_to_crs(source, dest, area)
+
+    obj = if normalize
+        pj_normalized = proj_normalize_for_visualization(pj_init)
+        proj_destroy(pj_init)
+        CRS2CRS(pj_normalized, direction)
+    else
+        CRS2CRS(pj_normalized, direction)
+    end
+
+    finalizer(obj) do
+        proj_destroy(obj.rep)
+        _free(proj.rep)
+    end
+
+    return obj
+end
+
+Base.inv(cs::CRS2CRS) = CRS2CRS(cs.rep, inv(cs.direction))
+
+function Base.inv(dir::PJ_DIRECTION)
+    return if dir == PJ_IDENT
+        PJ_IDENT
+    elseif dir == PJ_FWD
+        PJ_INV
+    else
+        PJ_FWD
+    end
+end
+
+function CoordinateTransformations.transform_deriv(cs::CRS2CRS, x)
+    coord = proj_coord(x...)
+    factors = proj_factors(cs.rep, coord)
+    return [dx_dlam dx_dphi; dy_dlam dy_dphi]
+end
+
+function (transformation::CRS2CRS)(x::T) where T
+    coord = if length(x) == 2
+        proj_coord(x..., 0, 0)
+    elseif length(x) == 3
+        proj_coord(x..., 0)
+    elseif length(x) == 4
+        proj_coord(x...)
+    else
+        error("Input must have length 2, 3 or 4! Found $(length(x)).")
+    end
+
+    xyzt = proj_trans(transformation.rep, transformation.direction, coord).xyzt
+
+    return if length(x) == 2
+        T(xyzt.x, xyzt.y)
+    elseif length(x) == 3
+        T(xyzt.x, xyzt.y, xyzt.z)
+    elseif length(x) == 4
+        proj_coord(xyzt.x, xyzt.y, xyzt.z, xyzt.t)
+    else
+        error("Input must have length 2, 3 or 4! Found $(length(x)).")
+    end
+end
+
+
+
+function proj_trans_generic(P, direction, x::Vector{Float64}, y::Vector{Float64}, z::Vector{Float64} = zeros(length(x)), t::Vector{Float64} = zeros(length(x)))
+    return proj_trans_generic(
+        P, direction,
+        x, sizeof(Float64), length(x),
+        y, sizeof(Float64), length(y),
+        z, sizeof(Float64), length(z),
+        t, sizeof(Float64), length(t),
+    )
+end

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -24,7 +24,7 @@ function CRS2CRS(source::Projection, dest::Projection, direction::PJ_DIRECTION =
         CRS2CRS(pj_normalized, direction)
     end
 
-    finalizer(obj) do
+    finalizer(obj) do obj
         proj_destroy(obj.rep)
     end
 
@@ -48,7 +48,7 @@ function CRS2CRS(source::String, dest::String, direction::PJ_DIRECTION = PJ_FWD;
         CRS2CRS(pj_normalized, direction)
     end
 
-    finalizer(obj) do
+    finalizer(obj) do obj
         proj_destroy(obj.rep)
     end
 

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -3,35 +3,6 @@ mutable struct CRS2CRS <: CoordinateTransformations.Transformation
     direction::PJ_DIRECTION
 end
 
-function CRS2CRS(source::Projection, dest::Projection, direction::PJ_DIRECTION = PJ_FWD; area = C_NULL, normalize = true)
-
-    if direction == PJ_IDENT || proj_is_equivalent_to(source.rep, dest.rep, PJ_COMP_EQUIVALENT) == 1
-        return IdentityTransformation()
-    end
-
-    pj_init = ccall(
-        (:proj_create_crs_to_crs_from_pj, PROJ_jll.libproj),
-        Ptr{Cvoid},
-        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cchar}),
-        source.rep,  dest.rep,   area,       C_NULL
-    )
-
-    obj = if normalize
-        pj_normalized = proj_normalize_for_visualization(pj_init)
-        proj_destroy(pj_init)
-        CRS2CRS(pj_normalized, direction)
-    else
-        CRS2CRS(pj_normalized, direction)
-    end
-
-    finalizer(obj) do obj
-        proj_destroy(obj.rep)
-    end
-
-    return obj
-end
-
-
 function CRS2CRS(source::String, dest::String, direction::PJ_DIRECTION = PJ_FWD; area = C_NULL, normalize = true)
 
     if direction == PJ_IDENT || source == direction

--- a/src/coordinate_transformations.jl
+++ b/src/coordinate_transformations.jl
@@ -26,7 +26,6 @@ function CRS2CRS(source::Projection, dest::Projection, direction::PJ_DIRECTION =
 
     finalizer(obj) do
         proj_destroy(obj.rep)
-        _free(proj.rep)
     end
 
     return obj
@@ -51,7 +50,6 @@ function CRS2CRS(source::String, dest::String, direction::PJ_DIRECTION = PJ_FWD;
 
     finalizer(obj) do
         proj_destroy(obj.rep)
-        _free(proj.rep)
     end
 
     return obj

--- a/src/overloads.jl
+++ b/src/overloads.jl
@@ -1,0 +1,29 @@
+# Convenience functions for PJ_COORD
+
+Base.length(::PJ_COORD) = 4
+
+Base.@propagate_inbounds function Base.getindex(coord::PJ_COORD, i::Int)
+    Base.@boundscheck @assert i ∈ (1, 2, 3, 4)
+
+    return if i == 1
+        coord.xyzt.x
+    elseif i == 2
+        coord.xyzt.y
+    elseif i == 3
+        coord.xyzt.x
+    elseif i == 4
+        coord.xyzt.t
+    end
+end
+
+# Make this interface (at least for vectors)
+# a little more Julian
+function proj_trans_generic(P, direction, x::Vector{Float64}, y::Vector{Float64}, z::Vector{Float64} = zeros(length(x)), t::Vector{Float64} = zeros(length(x)))
+    return proj_trans_generic(
+        P, direction,
+        x, sizeof(Float64), length(x),
+        y, sizeof(Float64), length(y),
+        z, sizeof(Float64), length(z),
+        t, sizeof(Float64), length(t),
+    )
+end

--- a/src/overloads.jl
+++ b/src/overloads.jl
@@ -1,5 +1,9 @@
 # Convenience functions for PJ_COORD
 
+function PJ_COORD(x::Real = 0, y::Real = 0, z::Real = 0, t::Real = 0)
+    return PJ_COORD(PJ_XYZT(Cdouble(x), Cdouble(y), Cdouble(z), Cdouble(t)))
+end
+
 Base.length(::PJ_COORD) = 4
 
 Base.@propagate_inbounds function Base.getindex(coord::PJ_COORD, i::Int)

--- a/src/overloads.jl
+++ b/src/overloads.jl
@@ -7,27 +7,6 @@ end
 Base.length(::PJ_COORD) = 4
 
 Base.@propagate_inbounds function Base.getindex(coord::PJ_COORD, i::Int)
-    Base.@boundscheck @assert i ∈ (1, 2, 3, 4)
-
-    return if i == 1
-        coord.xyzt.x
-    elseif i == 2
-        coord.xyzt.y
-    elseif i == 3
-        coord.xyzt.x
-    elseif i == 4
-        coord.xyzt.t
-    end
-end
-
-# Make this interface (at least for vectors)
-# a little more Julian
-function proj_trans_generic(P, direction, x::Vector{Float64}, y::Vector{Float64}, z::Vector{Float64} = zeros(length(x)), t::Vector{Float64} = zeros(length(x)))
-    return proj_trans_generic(
-        P, direction,
-        x, sizeof(Float64), length(x),
-        y, sizeof(Float64), length(y),
-        z, sizeof(Float64), length(z),
-        t, sizeof(Float64), length(t),
-    )
+    @boundscheck 1 <= i <= 4 || throw(BoundsError(coord,i))
+    return getfield(coord.xyzt, i) # getfield also works on Ints
 end

--- a/src/proj_c.jl
+++ b/src/proj_c.jl
@@ -104,7 +104,7 @@ function proj_trans_generic(P, direction, x, sx, nx, y, sy, ny, z, sz, nz, t, st
     ccall((:proj_trans_generic, libproj), Csize_t, (Ptr{PJ}, PJ_DIRECTION, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cdouble}, Csize_t, Csize_t), P, direction, x, sx, nx, y, sy, ny, z, sz, nz, t, st, nt)
 end
 
-function proj_coord(x, y, z, t)
+function proj_coord(x = 0, y = 0, z = 0, t = 0)
     ccall((:proj_coord, libproj), PJ_COORD, (Cdouble, Cdouble, Cdouble, Cdouble), x, y, z, t)
 end
 

--- a/src/proj_c.jl
+++ b/src/proj_c.jl
@@ -10,10 +10,34 @@ function proj_context_destroy(ctx = C_NULL)
     ccall((:proj_context_destroy, libproj), Ptr{PJ_CONTEXT}, (Ptr{PJ_CONTEXT},), ctx)
 end
 
+"""
+    proj_context_set_file_finder(proj_file_finder finder,
+                                 void * user_data,
+                                 PJ_CONTEXT * ctx) -> void
+
+Assign a file finder callback to a context.
+
+### Parameters
+* **finder**: Finder callback. May be NULL
+* **user_data**: User data provided to the finder callback. May be NULL.
+* **ctx**: PROJ context, or NULL for the default context.
+"""
 function proj_context_set_file_finder(finder, user_data, ctx = C_NULL)
     ccall((:proj_context_set_file_finder, libproj), Cvoid, (Ptr{PJ_CONTEXT}, proj_file_finder, Ptr{Cvoid}), ctx, finder, user_data)
 end
 
+"""
+    proj_context_set_search_paths(int count_paths,
+                                  const char *const * paths,
+                                  PJ_CONTEXT * ctx) -> void
+
+Sets search paths.
+
+### Parameters
+* **count_paths**: Number of paths. 0 if paths == NULL.
+* **paths**: Paths. May be NULL.
+* **ctx**: PROJ context, or NULL for the default context.
+"""
 function proj_context_set_search_paths(count_paths, paths, ctx = C_NULL)
     ccall((:proj_context_set_search_paths, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Cint, Ptr{Cstring}), ctx, count_paths, paths)
 end
@@ -27,10 +51,198 @@ function proj_context_get_use_proj4_init_rules(from_legacy_code_path, ctx = C_NU
 end
 
 """
+    proj_context_set_fileapi(const PROJ_FILE_API * fileapi,
+                             void * user_data,
+                             PJ_CONTEXT * ctx) -> int
+
+### Parameters
+* **fileapi**: Pointer to file API structure (content will be copied).
+* **user_data**: Arbitrary pointer provided by the user, and passed to the above callbacks. May be NULL.
+* **ctx**: PROJ context, or NULL
+
+### Returns
+TRUE in case of success.
+"""
+function proj_context_set_fileapi(fileapi, user_data, ctx = C_NULL)
+    ccall((:proj_context_set_fileapi, libproj), Cint, (Ptr{PJ_CONTEXT}, Ptr{PROJ_FILE_API}, Ptr{Cvoid}), ctx, fileapi, user_data)
+end
+
+"""
+    proj_context_set_sqlite3_vfs_name(const char * name,
+                                      PJ_CONTEXT * ctx) -> void
+
+### Parameters
+* **name**: SQLite3 VFS name. If NULL is passed, default implementation by SQLite will be used.
+* **ctx**: PROJ context, or NULL
+"""
+function proj_context_set_sqlite3_vfs_name(name, ctx = C_NULL)
+    ccall((:proj_context_set_sqlite3_vfs_name, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Cstring), ctx, name)
+end
+
+"""
+    proj_context_set_network_callbacks(proj_network_open_cbk_type open_cbk,
+                                       proj_network_close_cbk_type close_cbk,
+                                       proj_network_get_header_value_cbk_type get_header_value_cbk,
+                                       proj_network_read_range_type read_range_cbk,
+                                       void * user_data,
+                                       PJ_CONTEXT * ctx) -> int
+
+### Parameters
+* **open_cbk**: Callback to open a remote file given its URL
+* **close_cbk**: Callback to close a remote file.
+* **get_header_value_cbk**: Callback to get HTTP headers
+* **read_range_cbk**: Callback to read a range of bytes inside a remote file.
+* **user_data**: Arbitrary pointer provided by the user, and passed to the above callbacks. May be NULL.
+* **ctx**: PROJ context, or NULL
+
+### Returns
+TRUE in case of success.
+"""
+function proj_context_set_network_callbacks(open_cbk, close_cbk, get_header_value_cbk, read_range_cbk, user_data, ctx = C_NULL)
+    ccall((:proj_context_set_network_callbacks, libproj), Cint, (Ptr{PJ_CONTEXT}, proj_network_open_cbk_type, proj_network_close_cbk_type, proj_network_get_header_value_cbk_type, Cint, Ptr{Cvoid}), ctx, open_cbk, close_cbk, get_header_value_cbk, read_range_cbk, user_data)
+end
+
+"""
+    proj_context_set_enable_network(int enable,
+                                    PJ_CONTEXT * ctx) -> int
+
+### Parameters
+* **enable**: TRUE if network access is allowed.
+* **ctx**: PROJ context, or NULL
+
+### Returns
+TRUE if network access is possible. That is either libcurl is available, or an alternate interface has been set.
+"""
+function proj_context_set_enable_network(enabled, ctx = C_NULL)
+    ccall((:proj_context_set_enable_network, libproj), Cint, (Ptr{PJ_CONTEXT}, Cint), ctx, enabled)
+end
+
+"""
+    proj_context_is_network_enabled(PJ_CONTEXT * ctx) -> int
+
+### Parameters
+* **ctx**: PROJ context, or NULL
+
+### Returns
+TRUE if network access has been enabled
+"""
+function proj_context_is_network_enabled(ctx = C_NULL)
+    ccall((:proj_context_is_network_enabled, libproj), Cint, (Ptr{PJ_CONTEXT},), ctx)
+end
+
+"""
+    proj_context_set_url_endpoint(const char * url,
+                                  PJ_CONTEXT * ctx) -> void
+
+### Parameters
+* **url**: Endpoint URL. Must NOT be NULL.
+* **ctx**: PROJ context, or NULL
+"""
+function proj_context_set_url_endpoint(url, ctx = C_NULL)
+    ccall((:proj_context_set_url_endpoint, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Cstring), ctx, url)
+end
+
+"""
+    proj_grid_cache_set_enable(int enabled,
+                               PJ_CONTEXT * ctx) -> void
+
+### Parameters
+* **enabled**: TRUE if the cache is enabled.
+* **ctx**: PROJ context, or NULL
+"""
+function proj_grid_cache_set_enable(enabled, ctx = C_NULL)
+    ccall((:proj_grid_cache_set_enable, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Cint), ctx, enabled)
+end
+
+"""
+    proj_grid_cache_set_filename(const char * fullname,
+                                 PJ_CONTEXT * ctx) -> void
+
+### Parameters
+* **fullname**: Full name to the cache (encoded in UTF-8). If set to NULL, caching will be disabled.
+* **ctx**: PROJ context, or NULL
+"""
+function proj_grid_cache_set_filename(fullname, ctx = C_NULL)
+    ccall((:proj_grid_cache_set_filename, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Cstring), ctx, fullname)
+end
+
+"""
+    proj_grid_cache_set_max_size(int max_size_MB,
+                                 PJ_CONTEXT * ctx) -> void
+
+### Parameters
+* **max_size_MB**: Maximum size, in mega-bytes (1024*1024 bytes), or negative value to set unlimited size.
+* **ctx**: PROJ context, or NULL
+"""
+function proj_grid_cache_set_max_size(max_size_MB, ctx = C_NULL)
+    ccall((:proj_grid_cache_set_max_size, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Cint), ctx, max_size_MB)
+end
+
+"""
+    proj_grid_cache_set_ttl(int ttl_seconds,
+                            PJ_CONTEXT * ctx) -> void
+
+### Parameters
+* **ttl_seconds**: Delay in seconds. Use negative value for no expiration.
+* **ctx**: PROJ context, or NULL
+"""
+function proj_grid_cache_set_ttl(ttl_seconds, ctx = C_NULL)
+    ccall((:proj_grid_cache_set_ttl, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Cint), ctx, ttl_seconds)
+end
+
+"""
+    proj_grid_cache_clear(PJ_CONTEXT * ctx) -> void
+
+### Parameters
+* **ctx**: PROJ context, or NULL
+"""
+function proj_grid_cache_clear(ctx = C_NULL)
+    ccall((:proj_grid_cache_clear, libproj), Cvoid, (Ptr{PJ_CONTEXT},), ctx)
+end
+
+"""
+    proj_is_download_needed(const char * url_or_filename,
+                            int ignore_ttl_setting,
+                            PJ_CONTEXT * ctx) -> int
+
+### Parameters
+* **url_or_filename**: URL or filename (without directory component)
+* **ignore_ttl_setting**: If set to FALSE, PROJ will only check the recentness of an already downloaded file, if the delay between the last time it has been verified and the current time exceeds the TTL setting. This can save network accesses. If set to TRUE, PROJ will unconditionnally check from the server the recentness of the file.
+* **ctx**: PROJ context, or NULL
+
+### Returns
+TRUE if the file must be downloaded with proj_download_file()
+"""
+function proj_is_download_needed(url_or_filename, ignore_ttl_setting, ctx = C_NULL)
+    ccall((:proj_is_download_needed, libproj), Cint, (Ptr{PJ_CONTEXT}, Cstring, Cint), ctx, url_or_filename, ignore_ttl_setting)
+end
+
+"""
+    proj_download_file(const char * url_or_filename,
+                       int ignore_ttl_setting,
+                       int(*)(PJ_CONTEXT *, double pct, void *user_data) progress_cbk,
+                       void * user_data,
+                       PJ_CONTEXT * ctx) -> int
+
+### Parameters
+* **url_or_filename**: URL or filename (without directory component)
+* **ignore_ttl_setting**: If set to FALSE, PROJ will only check the recentness of an already downloaded file, if the delay between the last time it has been verified and the current time exceeds the TTL setting. This can save network accesses. If set to TRUE, PROJ will unconditionnally check from the server the recentness of the file.
+* **progress_cbk**: Progress callback, or NULL. The passed percentage is in the [0, 1] range. The progress callback must return TRUE if download must be continued.
+* **user_data**: User data to provide to the progress callback, or NULL
+* **ctx**: PROJ context, or NULL
+
+### Returns
+TRUE if the download was successful (or not needed)
+"""
+function proj_download_file(url_or_filename, ignore_ttl_setting, progress_cbk, user_data, ctx = C_NULL)
+    ccall((:proj_download_file, libproj), Cint, (Ptr{PJ_CONTEXT}, Cstring, Cint, Ptr{Cvoid}, Ptr{Cvoid}), ctx, url_or_filename, ignore_ttl_setting, progress_cbk, user_data)
+end
+
+"""
     proj_create(const char * text,
                 PJ_CONTEXT * ctx) -> PJ *
 
-Instantiate an object from a WKT string, PROJ string or object code (like "EPSG:4326", "urn:ogc:def:crs:EPSG::4326", "urn:ogc:def:coordinateOperation:EPSG::1671").
+Instantiate an object from a WKT string, PROJ string, object code (like "EPSG:4326", "urn:ogc:def:crs:EPSG::4326", "urn:ogc:def:coordinateOperation:EPSG::1671") or PROJJSON string.
 
 ### Parameters
 * **text**: String (must not be NULL)
@@ -51,6 +263,10 @@ function proj_create_crs_to_crs(source_crs, target_crs, area = C_NULL, ctx = C_N
     ccall((:proj_create_crs_to_crs, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Cstring, Cstring, Ptr{PJ_AREA}), ctx, source_crs, target_crs, area)
 end
 
+function proj_create_crs_to_crs_from_pj(source_crs, target_crs, area = C_NULL, ctx = C_NULL, options = C_NULL)
+    ccall((:proj_create_crs_to_crs_from_pj, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Ptr{PJ}, Ptr{PJ}, Ptr{PJ_AREA}, Ptr{Cstring}), ctx, source_crs, target_crs, area, options)
+end
+
 """
     proj_normalize_for_visualization(const PJ * obj,
                                      PJ_CONTEXT * ctx) -> PJ *
@@ -58,7 +274,7 @@ end
 Returns a PJ* object whose axis order is the one expected for visualization purposes.
 
 ### Parameters
-* **obj**: Object of type CoordinateOperation, created with proj_create_crs_to_crs() (must not be NULL)
+* **obj**: Object of type CRS, or CoordinateOperation created with proj_create_crs_to_crs() (must not be NULL)
 * **ctx**: PROJ context, or NULL for default context
 
 ### Returns
@@ -66,6 +282,10 @@ a new PJ* object to free with proj_destroy() in case of success, or nullptr in c
 """
 function proj_normalize_for_visualization(obj, ctx = C_NULL)
     ccall((:proj_normalize_for_visualization, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Ptr{PJ}), ctx, obj)
+end
+
+function proj_assign_context(pj, ctx)
+    ccall((:proj_assign_context, libproj), Cvoid, (Ptr{PJ}, Ptr{PJ_CONTEXT}), pj, ctx)
 end
 
 function proj_destroy(P)
@@ -104,7 +324,7 @@ function proj_trans_generic(P, direction, x, sx, nx, y, sy, ny, z, sz, nz, t, st
     ccall((:proj_trans_generic, libproj), Csize_t, (Ptr{PJ}, PJ_DIRECTION, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cdouble}, Csize_t, Csize_t), P, direction, x, sx, nx, y, sy, ny, z, sz, nz, t, st, nt)
 end
 
-function proj_coord(x = 0, y = 0, z = 0, t = 0)
+function proj_coord(x = 0.0, y = 0.0, z = 0.0, t = 0.0)
     ccall((:proj_coord, libproj), PJ_COORD, (Cdouble, Cdouble, Cdouble, Cdouble), x, y, z, t)
 end
 
@@ -220,11 +440,29 @@ function proj_rtodms(s, r, pos, neg)
     aftercare(ccall((:proj_rtodms, libproj), Cstring, (Cstring, Cdouble, Cint, Cint), s, r, pos, neg))
 end
 
+function proj_cleanup()
+    ccall((:proj_cleanup, libproj), Cvoid, ())
+end
+
 """
     proj_string_list_destroy(PROJ_STRING_LIST list) -> void
 """
 function proj_string_list_destroy(list)
     ccall((:proj_string_list_destroy, libproj), Cvoid, (PROJ_STRING_LIST,), list)
+end
+
+"""
+    proj_context_set_autoclose_database(int autoclose,
+                                        PJ_CONTEXT * ctx) -> void
+
+Set if the database must be closed after each C API call where it has been openeded, and automatically re-openeded when needed.
+
+### Parameters
+* **autoclose**: Boolean parameter
+* **ctx**: PROJ context, or NULL for default context
+"""
+function proj_context_set_autoclose_database(autoclose, ctx = C_NULL)
+    ccall((:proj_context_set_autoclose_database, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Cint), ctx, autoclose)
 end
 
 """
@@ -310,7 +548,7 @@ Instantiate an object from a WKT string.
 
 STRICT=YES/NO. Defaults to NO. When set to YES, strict validation will be enabled.
 * **out_warnings**: Pointer to a PROJ_STRING_LIST object, or NULL. If provided, *out_warnings will contain a list of warnings, typically for non recognized projection method or parameters. It must be freed with proj_string_list_destroy().
-* **out_grammar_errors**: Pointer to a PROJ_STRING_LIST object, or NULL. If provided, *out_grammar_errors will contain a list of errors regarding the WKT grammaer. It must be freed with proj_string_list_destroy().
+* **out_grammar_errors**: Pointer to a PROJ_STRING_LIST object, or NULL. If provided, *out_grammar_errors will contain a list of errors regarding the WKT grammar. It must be freed with proj_string_list_destroy().
 
 ### Returns
 Object that must be unreferenced with proj_destroy(), or NULL in case of error.
@@ -367,6 +605,35 @@ TRUE in case of success
 """
 function proj_uom_get_info_from_database(auth_name, code, out_name, out_conv_factor, out_category, ctx = C_NULL)
     ccall((:proj_uom_get_info_from_database, libproj), Cint, (Ptr{PJ_CONTEXT}, Cstring, Cstring, Ptr{Cstring}, Ptr{Cdouble}, Ptr{Cstring}), ctx, auth_name, code, out_name, out_conv_factor, out_category)
+end
+
+"""
+    proj_grid_get_info_from_database(const char * grid_name,
+                                     const char ** out_full_name,
+                                     const char ** out_package_name,
+                                     const char ** out_url,
+                                     int * out_direct_download,
+                                     int * out_open_license,
+                                     int * out_available,
+                                     PJ_CONTEXT * ctx) -> int
+
+Get information for a grid from a database lookup.
+
+### Parameters
+* **grid_name**: Grid name (must not be NULL)
+* **out_full_name**: Pointer to a string value to store the grid full filename. or NULL
+* **out_package_name**: Pointer to a string value to store the package name where the grid might be found. or NULL
+* **out_url**: Pointer to a string value to store the grid URL or the package URL where the grid might be found. or NULL
+* **out_direct_download**: Pointer to a int (boolean) value to store whether *out_url can be downloaded directly. or NULL
+* **out_open_license**: Pointer to a int (boolean) value to store whether the grid is released with an open license. or NULL
+* **out_available**: Pointer to a int (boolean) value to store whether the grid is available at runtime. or NULL
+* **ctx**: Context, or NULL for default context.
+
+### Returns
+TRUE in case of success.
+"""
+function proj_grid_get_info_from_database(grid_name, out_full_name, out_package_name, out_url, out_direct_download, out_open_license, out_available, ctx = C_NULL)
+    ccall((:proj_grid_get_info_from_database, libproj), Cint, (Ptr{PJ_CONTEXT}, Cstring, Ptr{Cstring}, Ptr{Cstring}, Ptr{Cstring}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), ctx, grid_name, out_full_name, out_package_name, out_url, out_direct_download, out_open_license, out_available)
 end
 
 """
@@ -482,6 +749,27 @@ function proj_is_equivalent_to(obj, other, criterion)
 end
 
 """
+    proj_is_equivalent_to_with_ctx(const PJ * obj,
+                                   const PJ * other,
+                                   PJ_COMPARISON_CRITERION criterion,
+                                   PJ_CONTEXT * ctx) -> int
+
+Return whether two objects are equivalent.
+
+### Parameters
+* **obj**: Object (must not be NULL)
+* **other**: Other object (must not be NULL)
+* **criterion**: Comparison criterion
+* **ctx**: PROJ context, or NULL for default context
+
+### Returns
+TRUE if they are equivalent
+"""
+function proj_is_equivalent_to_with_ctx(obj, other, criterion, ctx = C_NULL)
+    ccall((:proj_is_equivalent_to_with_ctx, libproj), Cint, (Ptr{PJ_CONTEXT}, Ptr{PJ}, Ptr{PJ}, PJ_COMPARISON_CRITERION), ctx, obj, other, criterion)
+end
+
+"""
     proj_is_crs(const PJ * obj) -> int
 
 Return whether an object is a CRS.
@@ -540,6 +828,36 @@ a string, or NULL in case of error or missing name.
 """
 function proj_get_id_code(obj, index)
     aftercare(ccall((:proj_get_id_code, libproj), Cstring, (Ptr{PJ}, Cint), obj, index))
+end
+
+"""
+    proj_get_remarks(const PJ * obj) -> const char *
+
+Get the remarks of an object.
+
+### Parameters
+* **obj**: Object (must not be NULL)
+
+### Returns
+a string, or NULL in case of error.
+"""
+function proj_get_remarks(obj)
+    aftercare(ccall((:proj_get_remarks, libproj), Cstring, (Ptr{PJ},), obj))
+end
+
+"""
+    proj_get_scope(const PJ * obj) -> const char *
+
+Get the scope of an object.
+
+### Parameters
+* **obj**: Object (must not be NULL)
+
+### Returns
+a string, or NULL in case of error or missing scope.
+"""
+function proj_get_scope(obj)
+    aftercare(ccall((:proj_get_scope, libproj), Cstring, (Ptr{PJ},), obj))
 end
 
 """
@@ -617,6 +935,33 @@ a string, or NULL in case of error.
 """
 function proj_as_proj_string(obj, type, ctx = C_NULL, options = C_NULL)
     aftercare(ccall((:proj_as_proj_string, libproj), Cstring, (Ptr{PJ_CONTEXT}, Ptr{PJ}, PJ_PROJ_STRING_TYPE, Ptr{Cstring}), ctx, obj, type, options))
+end
+
+"""
+    proj_as_projjson(const PJ * obj,
+                     PJ_CONTEXT * ctx,
+                     const char *const * options) -> const char *
+
+Get a PROJJSON string representation of an object.
+
+### Parameters
+* **obj**: Object (must not be NULL)
+* **ctx**: PROJ context, or NULL for default context
+* **options**: NULL-terminated list of strings with "KEY=VALUE" format. or NULL. Currently supported options are: 
+
+MULTILINE=YES/NO. Defaults to YES 
+
+
+INDENTATION_WIDTH=number. Defauls to 2 (when multiline output is on). 
+
+
+SCHEMA=string. URL to PROJJSON schema. Can be set to empty string to disable it.
+
+### Returns
+a string, or NULL in case of error.
+"""
+function proj_as_projjson(obj, ctx = C_NULL, options = C_NULL)
+    aftercare(ccall((:proj_as_projjson, libproj), Cstring, (Ptr{PJ_CONTEXT}, Ptr{PJ}, Ptr{Cstring}), ctx, obj, options))
 end
 
 """
@@ -933,6 +1278,22 @@ Restrict the potential pivot CRSs that can be used when trying to build a coordi
 """
 function proj_operation_factory_context_set_allowed_intermediate_crs(factory_ctx, list_of_auth_name_codes, ctx = C_NULL)
     ccall((:proj_operation_factory_context_set_allowed_intermediate_crs, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Ptr{PJ_OPERATION_FACTORY_CONTEXT}, Ptr{Cstring}), ctx, factory_ctx, list_of_auth_name_codes)
+end
+
+"""
+    proj_operation_factory_context_set_discard_superseded(PJ_OPERATION_FACTORY_CONTEXT * factory_ctx,
+                                                          int discard,
+                                                          PJ_CONTEXT * ctx) -> void
+
+Set whether transformations that are superseded (but not deprecated) should be discarded.
+
+### Parameters
+* **factory_ctx**: Operation factory context. must not be NULL
+* **discard**: superseded crs or not
+* **ctx**: PROJ context, or NULL for default context
+"""
+function proj_operation_factory_context_set_discard_superseded(factory_ctx, discard, ctx = C_NULL)
+    ccall((:proj_operation_factory_context_set_discard_superseded, libproj), Cvoid, (Ptr{PJ_CONTEXT}, Ptr{PJ_OPERATION_FACTORY_CONTEXT}, Cint), ctx, factory_ctx, discard)
 end
 
 """
@@ -1466,4 +1827,57 @@ TRUE in case of success, or FALSE if coordoperation is not compatible with a WKT
 """
 function proj_coordoperation_get_towgs84_values(coordoperation, out_values, value_count, emit_error_if_incompatible, ctx = C_NULL)
     ccall((:proj_coordoperation_get_towgs84_values, libproj), Cint, (Ptr{PJ_CONTEXT}, Ptr{PJ}, Ptr{Cdouble}, Cint, Cint), ctx, coordoperation, out_values, value_count, emit_error_if_incompatible)
+end
+
+"""
+    proj_coordoperation_create_inverse(const PJ * obj,
+                                       PJ_CONTEXT * ctx) -> PJ *
+
+Returns a PJ* coordinate operation object which represents the inverse operation of the specified coordinate operation.
+
+### Parameters
+* **obj**: Object of type CoordinateOperation (must not be NULL)
+* **ctx**: PROJ context, or NULL for default context
+
+### Returns
+a new PJ* object to free with proj_destroy() in case of success, or nullptr in case of error
+"""
+function proj_coordoperation_create_inverse(obj, ctx = C_NULL)
+    ccall((:proj_coordoperation_create_inverse, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Ptr{PJ}), ctx, obj)
+end
+
+"""
+    proj_concatoperation_get_step_count(const PJ * concatoperation,
+                                        PJ_CONTEXT * ctx) -> int
+
+Returns the number of steps of a concatenated operation.
+
+### Parameters
+* **concatoperation**: Concatenated operation (must not be NULL)
+* **ctx**: PROJ context, or NULL for default context
+
+### Returns
+the number of steps, or 0 in case of error.
+"""
+function proj_concatoperation_get_step_count(concatoperation, ctx = C_NULL)
+    ccall((:proj_concatoperation_get_step_count, libproj), Cint, (Ptr{PJ_CONTEXT}, Ptr{PJ}), ctx, concatoperation)
+end
+
+"""
+    proj_concatoperation_get_step(const PJ * concatoperation,
+                                  int i_step,
+                                  PJ_CONTEXT * ctx) -> PJ *
+
+Returns a step of a concatenated operation.
+
+### Parameters
+* **concatoperation**: Concatenated operation (must not be NULL)
+* **i_step**: Index of the step to extract. Between 0 and proj_concatoperation_get_step_count()-1
+* **ctx**: PROJ context, or NULL for default context
+
+### Returns
+Object that must be unreferenced with proj_destroy(), or NULL in case of error.
+"""
+function proj_concatoperation_get_step(concatoperation, i_step, ctx = C_NULL)
+    ccall((:proj_concatoperation_get_step, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Ptr{PJ}, Cint), ctx, concatoperation, i_step)
 end

--- a/src/proj_c.jl
+++ b/src/proj_c.jl
@@ -47,7 +47,7 @@ function proj_create_argv(argc, argv, ctx = C_NULL)
     ccall((:proj_create_argv, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Cint, Ptr{Cstring}), ctx, argc, argv)
 end
 
-function proj_create_crs_to_crs(source_crs, target_crs, area, ctx = C_NULL)
+function proj_create_crs_to_crs(source_crs, target_crs, area = C_NULL, ctx = C_NULL)
     ccall((:proj_create_crs_to_crs, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Cstring, Cstring, Ptr{PJ_AREA}), ctx, source_crs, target_crs, area)
 end
 

--- a/src/proj_common.jl
+++ b/src/proj_common.jl
@@ -3,9 +3,9 @@
 
 # Skipping MacroDefinition: PROJ_DLL __attribute__ ( ( visibility ( "default" ) ) )
 
-const PROJ_VERSION_MAJOR = 6
-const PROJ_VERSION_MINOR = 1
-const PROJ_VERSION_PATCH = 0
+const PROJ_VERSION_MAJOR = 7
+const PROJ_VERSION_MINOR = 0
+const PROJ_VERSION_PATCH = 1
 const PJ_DEFAULT_CTX = 0
 
 struct PJ_XYZT
@@ -48,7 +48,7 @@ struct PJ_INFO
     version::Cstring
     searchpath::Cstring
     paths::Ptr{Cstring}
-    path_count::Csize_t
+    path_count::Cint
 end
 
 struct PJ_PROJ_INFO
@@ -186,6 +186,34 @@ const PJ_LOG_FUNCTION = Ptr{Cvoid}
 const projCtx_t = Cvoid
 const PJ_CONTEXT = projCtx_t
 const proj_file_finder = Ptr{Cvoid}
+const PROJ_FILE_HANDLE = Cvoid
+
+@cenum PROJ_OPEN_ACCESS::UInt32 begin
+    PROJ_OPEN_ACCESS_READ_ONLY = 0
+    PROJ_OPEN_ACCESS_READ_UPDATE = 1
+    PROJ_OPEN_ACCESS_CREATE = 2
+end
+
+
+struct PROJ_FILE_API
+    version::Cint
+    open_cbk::Ptr{Cvoid}
+    size_t::Cvoid
+    seek_cbk::Ptr{Cvoid}
+    tell_cbk::Ptr{Cvoid}
+    close_cbk::Ptr{Cvoid}
+    exists_cbk::Ptr{Cvoid}
+    mkdir_cbk::Ptr{Cvoid}
+    unlink_cbk::Ptr{Cvoid}
+    rename_cbk::Ptr{Cvoid}
+end
+
+const PROJ_NETWORK_HANDLE = Cvoid
+const proj_network_open_cbk_type = Ptr{Cvoid}
+const proj_network_close_cbk_type = Ptr{Cvoid}
+const proj_network_get_header_value_cbk_type = Ptr{Cvoid}
+
+# Skipping Typedef: CXType_FunctionProto size_t
 
 @cenum PJ_DIRECTION::Int32 begin
     PJ_FWD = 1
@@ -199,6 +227,7 @@ const PROJ_STRING_LIST = Ptr{Cstring}
 
 "Guessed WKT \"dialect\""
 @cenum PJ_GUESSED_WKT_DIALECT::UInt32 begin
+    PJ_GUESSED_WKT2_2019 = 0
     PJ_GUESSED_WKT2_2018 = 0
     PJ_GUESSED_WKT2_2015 = 1
     PJ_GUESSED_WKT1_GDAL = 2
@@ -257,7 +286,9 @@ end
 @cenum PJ_WKT_TYPE::UInt32 begin
     PJ_WKT2_2015 = 0
     PJ_WKT2_2015_SIMPLIFIED = 1
+    PJ_WKT2_2019 = 2
     PJ_WKT2_2018 = 2
+    PJ_WKT2_2019_SIMPLIFIED = 3
     PJ_WKT2_2018_SIMPLIFIED = 3
     PJ_WKT1_GDAL = 4
     PJ_WKT1_ESRI = 5
@@ -274,6 +305,7 @@ end
     PROJ_GRID_AVAILABILITY_USED_FOR_SORTING = 0
     PROJ_GRID_AVAILABILITY_DISCARD_OPERATION_IF_MISSING_GRID = 1
     PROJ_GRID_AVAILABILITY_IGNORED = 2
+    PROJ_GRID_AVAILABILITY_KNOWN_AVAILABLE = 3
 end
 
 

--- a/src/proj_common.jl
+++ b/src/proj_common.jl
@@ -21,7 +21,7 @@ end
 
 const PJ_AREA = Cvoid
 
-struct PJ_FACTORS
+struct P5_FACTORS
     meridional_scale::Cdouble
     parallel_scale::Cdouble
     areal_scale::Cdouble

--- a/src/proj_common.jl
+++ b/src/proj_common.jl
@@ -21,7 +21,7 @@ end
 
 const PJ_AREA = Cvoid
 
-struct P5_FACTORS
+struct PJ_FACTORS
     meridional_scale::Cdouble
     parallel_scale::Cdouble
     areal_scale::Cdouble

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -106,4 +106,35 @@ end
     # Clean up
     Proj4.proj_destroy(pj)
     # TODO julia crashes if proj_destroy is called twice, i.e. on a null pointer
+
+    # Tests with CRS2CRS
+
+    cs = CRS2CRS(
+        "EPSG:4326",  # source
+        "+proj=utm +zone=32 +datum=WGS84",  # target, also EPSG:32632
+    )
+
+    # test the optional args for proj_coord also
+    a = Proj4.proj_coord(12, 55)
+    @test isbits(a)
+    @test a.xyzt.x === 12.0
+    @test a.xyzt.y === 55.0
+    @test a.xyzt.z === 0.0
+    @test a.xyzt.t === 0.0
+
+    # transform to UTM zone 32
+    b = cs(a)
+    @test b.xyzt.x ≈ 691875.632
+    @test b.xyzt.y ≈ 6098907.825
+    @test b.xyzt.z === 0.0
+    @test b.xyzt.t === 0.0
+
+    # inverse transform, back to geographical
+    b = inv(cs)(b)
+    @test b.xyzt.x ≈ 12.0
+    @test b.xyzt.y ≈ 55.0
+    @test b.xyzt.z === 0.0
+    @test b.xyzt.t === 0.0
+
+    @test cs(Float64[12, 55, 0, 0]) .≈ [691875.632, 6098907.825, 0.0, 0.0]
 end

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -106,37 +106,56 @@ end
     # Clean up
     Proj4.proj_destroy(pj)
     # TODO julia crashes if proj_destroy is called twice, i.e. on a null pointer
+end
 
-    # Tests with CRS2CRS
+@testset "CRS2CRS" begin
+    @testset "Quick start" begin
+        # Tests with CRS2CRS
 
-    cs = CRS2CRS(
-        "EPSG:4326",  # source
-        "+proj=utm +zone=32 +datum=WGS84",  # target, also EPSG:32632
-    )
+        cs = CRS2CRS(
+            "EPSG:4326",  # source
+            "+proj=utm +zone=32 +datum=WGS84",  # target, also EPSG:32632
+        )
 
-    # test the optional args for proj_coord also
-    a = Proj4.proj_coord(12, 55)
-    @test isbits(a)
-    @test a.xyzt.x === 12.0
-    @test a.xyzt.y === 55.0
-    @test a.xyzt.z === 0.0
-    @test a.xyzt.t === 0.0
+        # test the optional args for proj_coord also
+        a = Proj4.proj_coord(12, 55)
+        @test isbits(a)
+        @test a.xyzt.x === 12.0
+        @test a.xyzt.y === 55.0
+        @test a.xyzt.z === 0.0
+        @test a.xyzt.t === 0.0
 
-    # transform to UTM zone 32
-    b = cs(a)
-    @test b.xyzt.x ≈ 691875.632
-    @test b.xyzt.y ≈ 6098907.825
-    @test b.xyzt.z === 0.0
-    @test b.xyzt.t === 0.0
+        # transform to UTM zone 32
+        b = cs(a)
+        @test b.xyzt.x ≈ 691875.632
+        @test b.xyzt.y ≈ 6098907.825
+        @test b.xyzt.z === 0.0
+        @test b.xyzt.t === 0.0
 
-    # inverse transform, back to geographical
-    c = inv(cs)(b)
-    @test c.xyzt.x ≈ 12.0
-    @test c.xyzt.y ≈ 55.0
-    @test c.xyzt.z === 0.0
-    @test c.xyzt.t === 0.0
+        # inverse transform, back to geographical
+        c = inv(cs)(b)
+        @test c.xyzt.x ≈ 12.0
+        @test c.xyzt.y ≈ 55.0
+        @test c.xyzt.z === 0.0
+        @test c.xyzt.t === 0.0
+    end
 
-    # test with staticarrays
-    sa = SVector{4, Float64}(10,0,0,0)
-    @test_nowarn cs(sa)
+    @testset "StaticArrays" begin
+
+        using StaticArrays
+
+        cs = CRS2CRS(
+            "EPSG:4326",  # source
+            "+proj=utm +zone=32 +datum=WGS84",  # target, also EPSG:32632
+        )
+
+        sa = SVector{4, Float64}(12,55,0,0)
+        @test_nowarn cs(sa)
+
+        sa = SVector{3, Float64}(12,55,0)
+        @test_nowarn cs(sa)
+
+        sa = SVector{2, Float64}(12,55)
+        @test_nowarn cs(sa)
+    end
 end

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -135,6 +135,4 @@ end
     @test c.xyzt.y ≈ 55.0
     @test c.xyzt.z === 0.0
     @test c.xyzt.t === 0.0
-
-    @test cs(Float64[12, 55, 0, 0]) .≈ [691875.632, 6098907.825, 0.0, 0.0]
 end

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -135,4 +135,8 @@ end
     @test c.xyzt.y ≈ 55.0
     @test c.xyzt.z === 0.0
     @test c.xyzt.t === 0.0
+
+    # test with staticarrays
+    sa = SVector{4, Float64}(10,0,0,0)
+    @test_nowarn cs(sa)
 end

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -130,11 +130,11 @@ end
     @test b.xyzt.t === 0.0
 
     # inverse transform, back to geographical
-    b = inv(cs)(b)
-    @test b.xyzt.x ≈ 12.0
-    @test b.xyzt.y ≈ 55.0
-    @test b.xyzt.z === 0.0
-    @test b.xyzt.t === 0.0
+    c = inv(cs)(b)
+    @test c.xyzt.x ≈ 12.0
+    @test c.xyzt.y ≈ 55.0
+    @test c.xyzt.z === 0.0
+    @test c.xyzt.t === 0.0
 
     @test cs(Float64[12, 55, 0, 0]) .≈ [691875.632, 6098907.825, 0.0, 0.0]
 end

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -151,11 +151,14 @@ end
 
         sa = SVector{4, Float64}(12,55,0,0)
         @test_nowarn cs(sa)
+        @test size(cs(sa)) == size(sa)
 
         sa = SVector{3, Float64}(12,55,0)
         @test_nowarn cs(sa)
+        @test size(cs(sa)) == size(sa)
 
         sa = SVector{2, Float64}(12,55)
         @test_nowarn cs(sa)
+        @test size(cs(sa)) == size(sa)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Proj4
+using Proj4, StaticArrays
 using Test
 
 @testset "Proj4" begin


### PR DESCRIPTION
This PR implements the CoordinateTransformations interface through a new type `CRS2CRS`, constructed as:
```julia
cs = CRS2CRS("+proj=latlon", "+proj=moll")
# or
source_proj = Projection("+proj=latlon")
dest_proj = Projection("+proj_moll")
cs = CRS2CRS(source_proj, dest_proj)
# Inverse transformations also exist
cs = CRS2CRS("+proj=latlon", "+proj=moll", Proj4.PJ_INV)
# and existing transformations can be trivially inverted by
Base.inv(cs)

# CRS2CRS is callable
using GeoMakie
cs = CRS2CRS("+proj=latlon", "+proj=moll")
lines(cs.(GeoMakie.COASTLINES_LINEVEC))
```
![transform_func](https://user-images.githubusercontent.com/32143268/83508405-81c82680-a4e7-11ea-9c2b-65dbd0b0e394.png)
There are also some typo fixes, and `proj_coord` has all of its arguments marked as optional.

I'll add some docs once we agree on the API.