### PR TITLE
optional args for proj_create_crs_to_crs and proj_coord

### DIFF
--- a/gen/wrap_proj.jl
+++ b/gen/wrap_proj.jl
@@ -91,6 +91,17 @@ function rewriter(x::Expr)
 
         fargs2 = copy(fargs)
         if !isempty(fargs)
+            # make area optional
+            if f in (:proj_create_crs_to_crs, :proj_create_crs_to_crs_from_pj)
+                optpos = findfirst(==(:area), fargs)
+                keywordify!(fargs2, argpos, optpos)
+            elseif f === :proj_coord
+                # proj_coord(x, y, z, t) to proj_coord(x = 0.0, y = 0.0, z = 0.0, t = 0.0)
+                fargs2[1] = Expr(:kw, :x, 0.0)
+                fargs2[2] = Expr(:kw, :y, 0.0)
+                fargs2[3] = Expr(:kw, :z, 0.0)
+                fargs2[4] = Expr(:kw, :t, 0.0)
+            end
             # ctx is always the first argument
             if fargs[1] === :ctx
                 keywordify!(fargs2, argpos, 1)

--- a/src/proj_c.jl
+++ b/src/proj_c.jl
@@ -305,11 +305,11 @@ function proj_create_argv(argc, argv, ctx = C_NULL)
     ccall((:proj_create_argv, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Cint, Ptr{Cstring}), ctx, argc, argv)
 end
 
-function proj_create_crs_to_crs(source_crs, target_crs, area, ctx = C_NULL)
+function proj_create_crs_to_crs(source_crs, target_crs, area = C_NULL, ctx = C_NULL)
     ccall((:proj_create_crs_to_crs, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Cstring, Cstring, Ptr{PJ_AREA}), ctx, source_crs, target_crs, area)
 end
 
-function proj_create_crs_to_crs_from_pj(source_crs, target_crs, area, ctx = C_NULL, options = C_NULL)
+function proj_create_crs_to_crs_from_pj(source_crs, target_crs, area = C_NULL, ctx = C_NULL, options = C_NULL)
     ccall((:proj_create_crs_to_crs_from_pj, libproj), Ptr{PJ}, (Ptr{PJ_CONTEXT}, Ptr{PJ}, Ptr{PJ}, Ptr{PJ_AREA}, Ptr{Cstring}), ctx, source_crs, target_crs, area, options)
 end
 
@@ -378,7 +378,7 @@ function proj_trans_generic(P, direction, x, sx, nx, y, sy, ny, z, sz, nz, t, st
     ccall((:proj_trans_generic, libproj), Csize_t, (Ptr{PJ}, PJ_DIRECTION, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cdouble}, Csize_t, Csize_t), P, direction, x, sx, nx, y, sy, ny, z, sz, nz, t, st, nt)
 end
 
-function proj_coord(x, y, z, t)
+function proj_coord(x = 0.0, y = 0.0, z = 0.0, t = 0.0)
     ccall((:proj_coord, libproj), PJ_COORD, (Cdouble, Cdouble, Cdouble, Cdouble), x, y, z, t)
 end
 

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -69,7 +69,6 @@ end
     pj = Proj4.proj_create_crs_to_crs(
         "EPSG:4326",  # source
         "+proj=utm +zone=32 +datum=WGS84",  # target, also EPSG:32632
-        C_NULL,  # area
     )
 
     # This will ensure that the order of coordinates for the input CRS
@@ -82,7 +81,7 @@ end
     # a coordinate union representing Copenhagen: 55d N, 12d E
     # Given that we have used proj_normalize_for_visualization(), the order of
     # coordinates is longitude, latitude, and values are expressed in degrees.
-    a = Proj4.proj_coord(12, 55, 0, 0)
+    a = Proj4.proj_coord(12, 55)
     @test isbits(a)
     @test a.xyzt.x === 12.0
     @test a.xyzt.y === 55.0


### PR DESCRIPTION
To make them slighly more convenient to use. Taken from #44.