### PR TITLE
make PJ_COORD a FieldVector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.7.3"
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"

--- a/gen/wrap_proj.jl
+++ b/gen/wrap_proj.jl
@@ -50,6 +50,8 @@ function rewriter(xs::Vector)
         if x isa String
             push!(rewritten, x)
             continue
+        elseif x.head == :struct && x.args[2] in coord_union
+            continue
         end
         @assert x isa Expr
 
@@ -154,12 +156,16 @@ const doc = readxml(xmlpath)
 includedir = joinpath(PROJ_jll.artifact_dir, "include")
 headerfiles = [joinpath(includedir, "proj.h")]
 
-pj_coord = :(struct PJ_COORD <: FieldVector{4, Float64}
+const pj_coord = :(struct PJ_COORD <: FieldVector{4, Float64}
     x::Float64
     y::Float64
     z::Float64
     t::Float64
 end)
+
+# https://proj.org/development/reference/datatypes.html#c.PJ_COORD
+const coord_union = [:PJ_XYZT, :PJ_UVWT, :PJ_LPZT, :PJ_GEOD, :PJ_OPK,
+    :PJ_ENU, :PJ_XYZ, :PJ_UVW, :PJ_LPZ, :PJ_XY, :PJ_UV, :PJ_LP]
 
 wc = init(; headers = headerfiles,
             output_file = joinpath(@__DIR__, "..", "src", "proj_c.jl"),

--- a/gen/wrap_proj.jl
+++ b/gen/wrap_proj.jl
@@ -157,7 +157,7 @@ headerfiles = [joinpath(includedir, "proj.h")]
 # PJ_COORD becomes `Coord <: FieldVector{4, Float64}` and the rest is left out altogether
 # https://proj.org/development/reference/datatypes.html#c.PJ_COORD
 const coord_union = [:PJ_COORD, :PJ_XYZT, :PJ_UVWT, :PJ_LPZT, :PJ_GEOD, :PJ_OPK,
-    :PJ_ENU, :PJ_XYZ, :PJ_UVW, :PJ_LPZ, :PJ_XY, :PJ_UV, :PJ_LP]
+    :PJ_ENU, :PJ_XYZ, :PJ_UVW, :PJ_LPZ, :PJ_XY, :PJ_UV]
 
 wc = init(; headers = headerfiles,
             output_file = joinpath(@__DIR__, "..", "src", "proj_c.jl"),

--- a/src/Proj4.jl
+++ b/src/Proj4.jl
@@ -12,9 +12,13 @@ export Projection, # proj_types.jl
 # geodesic support
 export geod_direct, geod_inverse, geod_destination, geod_distance
 
+# these are part of the deprecated PROJ API, and will be removed soon
 include("projection_codes.jl") # ESRI and EPSG projection strings
 include("proj_capi.jl") # low-level C-facing functions (corresponding to src/proj_api.h)
 include("proj_geodesic.jl") # low-level C-facing functions (corresponding to src/geodesic.h)
+
+# these are part of the new PROJ API
+include("coord.jl")
 include("proj_common.jl")
 include("proj_c.jl")
 include("error.jl")

--- a/src/Proj4.jl
+++ b/src/Proj4.jl
@@ -2,6 +2,7 @@ module Proj4
 
 using PROJ_jll
 using CEnum
+using StaticArrays
 
 export Projection, # proj_types.jl
        transform, transform!,  # proj_functions.jl

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -1,0 +1,17 @@
+"""
+    Coord <: FieldVector{4, Float64}
+
+General purpose coordinate type, applicable in two, three and four dimensions. This is the
+default coordinate datatype used in PROJ.
+
+Elements can be retrieved either by index 1-4, or by field x, y, z, t. If a Coord does not
+represent a cartesian coordinate, using the index may be more clear, as the other coordinate
+types listed in the [PJ_COORD docs](https://proj.org/development/reference/datatypes.html#c.PJ_COORD)
+are not addressable by name.
+"""
+struct Coord <: FieldVector{4, Float64}
+    x::Float64
+    y::Float64
+    z::Float64
+    t::Float64
+end

--- a/src/proj_c.jl
+++ b/src/proj_c.jl
@@ -367,11 +367,11 @@ function proj_degree_output(P, dir)
 end
 
 function proj_trans(P, direction, coord)
-    ccall((:proj_trans, libproj), PJ_COORD, (Ptr{PJ}, PJ_DIRECTION, PJ_COORD), P, direction, coord)
+    ccall((:proj_trans, libproj), Coord, (Ptr{PJ}, PJ_DIRECTION, Coord), P, direction, coord)
 end
 
 function proj_trans_array(P, direction, n, coord)
-    ccall((:proj_trans_array, libproj), Cint, (Ptr{PJ}, PJ_DIRECTION, Csize_t, Ptr{PJ_COORD}), P, direction, n, coord)
+    ccall((:proj_trans_array, libproj), Cint, (Ptr{PJ}, PJ_DIRECTION, Csize_t, Ptr{Coord}), P, direction, n, coord)
 end
 
 function proj_trans_generic(P, direction, x, sx, nx, y, sy, ny, z, sz, nz, t, st, nt)
@@ -379,31 +379,31 @@ function proj_trans_generic(P, direction, x, sx, nx, y, sy, ny, z, sz, nz, t, st
 end
 
 function proj_coord(x = 0.0, y = 0.0, z = 0.0, t = 0.0)
-    ccall((:proj_coord, libproj), PJ_COORD, (Cdouble, Cdouble, Cdouble, Cdouble), x, y, z, t)
+    ccall((:proj_coord, libproj), Coord, (Cdouble, Cdouble, Cdouble, Cdouble), x, y, z, t)
 end
 
 function proj_roundtrip(P, direction, n, coord)
-    ccall((:proj_roundtrip, libproj), Cdouble, (Ptr{PJ}, PJ_DIRECTION, Cint, Ptr{PJ_COORD}), P, direction, n, coord)
+    ccall((:proj_roundtrip, libproj), Cdouble, (Ptr{PJ}, PJ_DIRECTION, Cint, Ptr{Coord}), P, direction, n, coord)
 end
 
 function proj_lp_dist(P, a, b)
-    ccall((:proj_lp_dist, libproj), Cdouble, (Ptr{PJ}, PJ_COORD, PJ_COORD), P, a, b)
+    ccall((:proj_lp_dist, libproj), Cdouble, (Ptr{PJ}, Coord, Coord), P, a, b)
 end
 
 function proj_lpz_dist(P, a, b)
-    ccall((:proj_lpz_dist, libproj), Cdouble, (Ptr{PJ}, PJ_COORD, PJ_COORD), P, a, b)
+    ccall((:proj_lpz_dist, libproj), Cdouble, (Ptr{PJ}, Coord, Coord), P, a, b)
 end
 
 function proj_xy_dist(a, b)
-    ccall((:proj_xy_dist, libproj), Cdouble, (PJ_COORD, PJ_COORD), a, b)
+    ccall((:proj_xy_dist, libproj), Cdouble, (Coord, Coord), a, b)
 end
 
 function proj_xyz_dist(a, b)
-    ccall((:proj_xyz_dist, libproj), Cdouble, (PJ_COORD, PJ_COORD), a, b)
+    ccall((:proj_xyz_dist, libproj), Cdouble, (Coord, Coord), a, b)
 end
 
 function proj_geod(P, a, b)
-    ccall((:proj_geod, libproj), PJ_COORD, (Ptr{PJ}, PJ_COORD, PJ_COORD), P, a, b)
+    ccall((:proj_geod, libproj), Coord, (Ptr{PJ}, Coord, Coord), P, a, b)
 end
 
 function proj_context_errno(ctx = C_NULL)
@@ -439,7 +439,7 @@ function proj_log_func(app_data, logf, ctx = C_NULL)
 end
 
 function proj_factors(P, lp)
-    ccall((:proj_factors, libproj), PJ_FACTORS, (Ptr{PJ}, PJ_COORD), P, lp)
+    ccall((:proj_factors, libproj), PJ_FACTORS, (Ptr{PJ}, Coord), P, lp)
 end
 
 function proj_info()
@@ -1489,7 +1489,7 @@ end
 the index in operations that would be used to transform coord. Or -1 in case of error, or no match.
 """
 function proj_get_suggested_operation(operations, direction, coord, ctx = C_NULL)
-    ccall((:proj_get_suggested_operation, libproj), Cint, (Ptr{PJ_CONTEXT}, Ptr{PJ_OBJ_LIST}, PJ_DIRECTION, PJ_COORD), ctx, operations, direction, coord)
+    ccall((:proj_get_suggested_operation, libproj), Cint, (Ptr{PJ_CONTEXT}, Ptr{PJ_OBJ_LIST}, PJ_DIRECTION, Coord), ctx, operations, direction, coord)
 end
 
 """

--- a/src/proj_common.jl
+++ b/src/proj_common.jl
@@ -9,13 +9,6 @@ const PROJ_VERSION_MINOR = 2
 const PROJ_VERSION_PATCH = 0
 const PJ_DEFAULT_CTX = 0
 
-struct PJ_XYZT
-    x::Cdouble
-    y::Cdouble
-    z::Cdouble
-    t::Cdouble
-end
-
 struct PJ_COORD <: FieldVector{4, Float64}
     x::Float64
     y::Float64
@@ -63,11 +56,6 @@ struct PJ_PROJ_INFO
     accuracy::Cdouble
 end
 
-struct PJ_LP
-    lam::Cdouble
-    phi::Cdouble
-end
-
 struct PJ_GRID_INFO
     gridname::NTuple{32, UInt8}
     filename::NTuple{260, UInt8}
@@ -113,66 +101,6 @@ end
 struct PJ_PRIME_MERIDIANS
     id::Cstring
     defn::Cstring
-end
-
-struct PJ_UVWT
-    u::Cdouble
-    v::Cdouble
-    w::Cdouble
-    t::Cdouble
-end
-
-struct PJ_LPZT
-    lam::Cdouble
-    phi::Cdouble
-    z::Cdouble
-    t::Cdouble
-end
-
-struct PJ_OPK
-    o::Cdouble
-    p::Cdouble
-    k::Cdouble
-end
-
-struct PJ_ENU
-    e::Cdouble
-    n::Cdouble
-    u::Cdouble
-end
-
-struct PJ_GEOD
-    s::Cdouble
-    a1::Cdouble
-    a2::Cdouble
-end
-
-struct PJ_UV
-    u::Cdouble
-    v::Cdouble
-end
-
-struct PJ_XY
-    x::Cdouble
-    y::Cdouble
-end
-
-struct PJ_XYZ
-    x::Cdouble
-    y::Cdouble
-    z::Cdouble
-end
-
-struct PJ_UVW
-    u::Cdouble
-    v::Cdouble
-    w::Cdouble
-end
-
-struct PJ_LPZ
-    lam::Cdouble
-    phi::Cdouble
-    z::Cdouble
 end
 
 @cenum PJ_LOG_LEVEL::UInt32 begin

--- a/src/proj_common.jl
+++ b/src/proj_common.jl
@@ -16,8 +16,11 @@ struct PJ_XYZT
     t::Cdouble
 end
 
-struct PJ_COORD
-    xyzt::PJ_XYZT
+struct PJ_COORD <: FieldVector{4, Float64}
+    x::Float64
+    y::Float64
+    z::Float64
+    t::Float64
 end
 
 const PJ_AREA = Cvoid

--- a/src/proj_common.jl
+++ b/src/proj_common.jl
@@ -8,14 +8,6 @@ const PROJ_VERSION_MAJOR = 7
 const PROJ_VERSION_MINOR = 2
 const PROJ_VERSION_PATCH = 0
 const PJ_DEFAULT_CTX = 0
-
-struct PJ_COORD <: FieldVector{4, Float64}
-    x::Float64
-    y::Float64
-    z::Float64
-    t::Float64
-end
-
 const PJ_AREA = Cvoid
 
 struct P5_FACTORS

--- a/src/proj_common.jl
+++ b/src/proj_common.jl
@@ -48,6 +48,11 @@ struct PJ_PROJ_INFO
     accuracy::Cdouble
 end
 
+struct PJ_LP
+    lam::Cdouble
+    phi::Cdouble
+end
+
 struct PJ_GRID_INFO
     gridname::NTuple{32, UInt8}
     filename::NTuple{260, UInt8}

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -85,7 +85,7 @@ end
     a = Proj4.proj_coord(12, 55)
     @test a isa AbstractVector
     @test a isa FieldVector{4, Float64}
-    @test a isa Proj4.PJ_COORD
+    @test a isa Proj4.Coord
     @test eltype(a) == Float64
     @test length(a) == 4
     @test sum(a) == 12 + 55

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -1,4 +1,5 @@
 using Test
+using StaticArrays
 import Proj4
 
 @testset "Error handling" begin
@@ -82,25 +83,32 @@ end
     # Given that we have used proj_normalize_for_visualization(), the order of
     # coordinates is longitude, latitude, and values are expressed in degrees.
     a = Proj4.proj_coord(12, 55)
+    @test a isa AbstractVector
+    @test a isa FieldVector{4, Float64}
+    @test a isa Proj4.PJ_COORD
+    @test eltype(a) == Float64
+    @test length(a) == 4
+    @test sum(a) == 12 + 55
+    @test a[2] === 55.0
     @test isbits(a)
-    @test a.xyzt.x === 12.0
-    @test a.xyzt.y === 55.0
-    @test a.xyzt.z === 0.0
-    @test a.xyzt.t === 0.0
+    @test a.x === 12.0
+    @test a.y === 55.0
+    @test a.z === 0.0
+    @test a.t === 0.0
 
     # transform to UTM zone 32
     b = Proj4.proj_trans(pj, Proj4.PJ_FWD, a)
-    @test b.xyzt.x ≈ 691875.632
-    @test b.xyzt.y ≈ 6098907.825
-    @test b.xyzt.z === 0.0
-    @test b.xyzt.t === 0.0
+    @test b.x ≈ 691875.632
+    @test b.y ≈ 6098907.825
+    @test b.z === 0.0
+    @test b.t === 0.0
 
     # inverse transform, back to geographical
     b = Proj4.proj_trans(pj, Proj4.PJ_INV, b)
-    @test b.xyzt.x ≈ 12.0
-    @test b.xyzt.y ≈ 55.0
-    @test b.xyzt.z === 0.0
-    @test b.xyzt.t === 0.0
+    @test b.x ≈ 12.0
+    @test b.y ≈ 55.0
+    @test b.z === 0.0
+    @test b.t === 0.0
 
     # Clean up
     Proj4.proj_destroy(pj)


### PR DESCRIPTION
@c42f this is what you had in mind in your comment here https://github.com/JuliaGeo/Proj4.jl/pull/44#pullrequestreview-429425928 right?

https://proj.org/development/reference/datatypes.html#complex-coordinate-types

This will allow access to the PJ_COORD coordinates by either index or x,y,z,t index. That means it matches the first two here:

```
typedef union {
    double v[4];
    PJ_XYZT xyzt;
    PJ_UVWT uvwt;
    PJ_LPZT lpzt;
    PJ_GEOD geod;
    PJ_OPK opk;
    PJ_ENU enu;
    PJ_XYZ  xyz;
    PJ_UVW  uvw;
    PJ_LPZ  lpz;
    PJ_XY   xy;
    PJ_UV   uv;
    PJ_LP   lp;
} PJ_COORD ;
```

This feels slightly odd since we are making the PJ_XYZT special. But if it is really a PJ_UVWT folks can just use `p[1]` instead of `p.x`, which would be misnaming the element. Though judging by the argument names in https://proj.org/development/reference/functions.html#c.proj_coord it seems PROJ itself sometimes does the same.