### PR TITLE
Prepare a patch release for Julia 1.6+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Proj4"
 uuid = "9a7e659c-8ee8-5706-894e-f68f43bc57ea"
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -9,7 +9,8 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
-PROJ_jll = "7.2"
+PROJ_jll = "700.200"
+StaticArrays = "1"
 julia = "1.3"
 
 [extras]

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -1,17 +1,1 @@
-"""
-    Coord <: FieldVector{4, Float64}
-
-General purpose coordinate type, applicable in two, three and four dimensions. This is the
-default coordinate datatype used in PROJ.
-
-Elements can be retrieved either by index 1-4, or by field x, y, z, t. If a Coord does not
-represent a cartesian coordinate, using the index may be more clear, as the other coordinate
-types listed in the [PJ_COORD docs](https://proj.org/development/reference/datatypes.html#c.PJ_COORD)
-are not addressable by name.
-"""
-struct Coord <: FieldVector{4, Float64}
-    x::Float64
-    y::Float64
-    z::Float64
-    t::Float64
-end
+const Coord = SVector{4, Float64}

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -84,31 +84,30 @@ end
     # coordinates is longitude, latitude, and values are expressed in degrees.
     a = Proj4.proj_coord(12, 55)
     @test a isa AbstractVector
-    @test a isa FieldVector{4, Float64}
+    @test a isa SVector{4,Float64}
     @test a isa Proj4.Coord
     @test eltype(a) == Float64
     @test length(a) == 4
     @test sum(a) == 12 + 55
-    @test a[2] === 55.0
     @test isbits(a)
-    @test a.x === 12.0
-    @test a.y === 55.0
-    @test a.z === 0.0
-    @test a.t === 0.0
+    @test a[1] === 12.0
+    @test a[2] === 55.0
+    @test a[3] === 0.0
+    @test a[4] === 0.0
 
     # transform to UTM zone 32
     b = Proj4.proj_trans(pj, Proj4.PJ_FWD, a)
-    @test b.x ≈ 691875.632
-    @test b.y ≈ 6098907.825
-    @test b.z === 0.0
-    @test b.t === 0.0
+    @test b[1] ≈ 691875.632
+    @test b[2] ≈ 6098907.825
+    @test b[3] === 0.0
+    @test b[4] === 0.0
 
     # inverse transform, back to geographical
     b = Proj4.proj_trans(pj, Proj4.PJ_INV, b)
-    @test b.x ≈ 12.0
-    @test b.y ≈ 55.0
-    @test b.z === 0.0
-    @test b.t === 0.0
+    @test b[1] ≈ 12.0
+    @test b[2] ≈ 55.0
+    @test b[3] === 0.0
+    @test b[4] === 0.0
 
     # Clean up
     Proj4.proj_destroy(pj)


### PR DESCRIPTION
The first commit takes the first commit from #51, because that partly reverts a change that is already on master but is not yet released. Since the PROJ6 API is not properly wrapped yet I think a patch release is fine here? No packages use it so far.

The second commit is done to be able to provide builds that work across julia minor version, even if shipped libraries like libcurl update.

This new PROJ_jll build will also be required in GDAL.jl, so I'd like to tag it to allow using these builds on both packages at the same time.

Ref
https://github.com/JuliaPackaging/Yggdrasil/pull/2545
https://github.com/JuliaPackaging/Yggdrasil/issues/2401

