### PR TITLE
Fix overwriting 4th coordinate in coord.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Proj4"
 uuid = "9a7e659c-8ee8-5706-894e-f68f43bc57ea"
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -141,7 +141,7 @@ end
 
 function (trans::Transformation)(coord::StaticVector{4,<:AbstractFloat})
     T = similar_type(coord)
-    coord = SVector{4, Float64}(coord[1], coord[2], coord[3], Inf)
+    coord = SVector{4, Float64}(coord[1], coord[2], coord[3], coord[4])
     p = proj_trans(trans.pj, PJ_FWD, coord)
     return T(p)
 end

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -143,6 +143,9 @@ end
     @test target_crs isa Ptr{Nothing}
     trans = Proj4.Transformation(source_crs, target_crs)
 
+    # Check that altitude and time inputs are correctly forwarded from the transformation
+    @test trans(SA_F64[52.16, 5.39, 5, 2020]) ≈ SA[155191.3538124342, 463537.1362732911, 5.0, 2020.0]
+
     a = Proj4.proj_coord(52.16, 5.39)
     b = Proj4.proj_trans(trans.pj, Proj4.PJ_FWD, a)
     @test a != b


### PR DESCRIPTION
I am studying a bit the internal of Proj4.jl to undertand how to exploit it better, but it seem that the current implementation on the new API wrongly overwrites the 4th coordinate if this is provided with a 4 element SVector as input.