### PR TITLE
Add a direction field to Transformation

### DIFF
--- a/src/Proj.jl
+++ b/src/Proj.jl
@@ -6,6 +6,7 @@ using StaticArrays
 using CoordinateTransformations
 
 export PROJ_jll
+export PJ_DIRECTION, PJ_FWD, PJ_IDENT, PJ_INV
 
 # type aliases
 const Coord = SVector{4,Float64}

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -63,6 +63,7 @@ mutable struct Transformation <: CoordinateTransformations.Transformation
         end
         return trans
     end
+
 end
 
 function Transformation(
@@ -127,7 +128,15 @@ function Base.inv(
     ctx::Ptr{PJ_CONTEXT} = C_NULL,
     always_xy::Bool = false,
 )
-    return Transformation(trans.pj, trans.direction == PJ_FWD ? PJ_INV : PJ_FWD)
+    source_crs = proj_get_source_crs(trans.pj)
+    target_crs = proj_get_target_crs(trans.pj)
+
+    return Transformation(
+        source_crs, target_crs;
+        direction = trans.direction == PJ_FWD ? PJ_INV : PJ_FWD,
+        area = area,
+        ctx = ctx,
+    )
 end
 
 function (trans::Transformation)(coord::StaticVector{2,<:AbstractFloat})


### PR DESCRIPTION
Pursuant to discussion in #57, this adds a `direction::PJ_DIRECTION` field to the Transformation struct.  It also implements this as a keyword argument in constructors, and implements it in the transformation functions.