### PR TITLE
Remove StaticArrays dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.0"
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
+NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,23 +1,21 @@
 name = "Proj"
 uuid = "c94c279d-25a6-4763-9509-64d165bea63e"
-version = "0.8.0"
+version = "1.0.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"
 CoordinateTransformations = "0.6"
 PROJ_jll = "900"
-StaticArrays = "1"
 julia = "1.6"
 
 [extras]
-GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["GeometryBasics", "Test"]
+test = ["StaticArrays", "Test"]

--- a/README.md
+++ b/README.md
@@ -2,22 +2,25 @@
 
 [![CI](https://github.com/JuliaGeo/Proj.jl/workflows/CI/badge.svg)](https://github.com/JuliaGeo/Proj.jl/actions?query=workflow%3ACI)
 
-A simple Julia wrapper around the [PROJ](https://proj.org/) cartographic projections library.
+A simple [Julia](https://julialang.org/) wrapper around the [PROJ](https://proj.org/)
+cartographic projections library.
 
 Quickstart, based on the [PROJ docs](https://proj.org/development/quickstart.html):
 
 ```julia
 using Proj
 
-# Proj.jl implements the CoordinateTransformations.jl API
-# A Proj.Transformation needs the source and target coordinate reference systems
+# Proj.jl implements the CoordinateTransformations.jl API.
+# A Proj.Transformation needs the source and target coordinate reference systems.
 trans = Proj.Transformation("EPSG:4326", "+proj=utm +zone=32 +datum=WGS84")
 
-# Once created, you can call this object to transform points
-# the result will be a SVector from StaticArrays.jl
+# Once created, you can call this object to transform points.
+# The result will be a tuple of Float64s, of length 2, 3 or 4 depending on the input length.
+# The 3rd coordinate is elevation (default 0), and the 4th is time (default Inf).
 # Here the (latitude, longitude) of Copenhagen is entered
-trans([55, 12])
-# -> SVector{2, Float64}(691875.632, 6098907.825)
+trans(55, 12)
+# -> (691875.632137542, 6.098907825129169e6)
+# Passing coordinates as a single tuple or vector also works.
 
 # Note that above the latitude is passed first, because that is the axis order that the
 # EPSG mandates. If you want to pass in (longitude, latitude) / (x, y), you can set the
@@ -25,11 +28,11 @@ trans([55, 12])
 trans = Proj.Transformation("EPSG:4326", "+proj=utm +zone=32 +datum=WGS84", always_xy=true)
 
 # now we input (longitude, latitude), and get the same result as above
-trans([12, 55])
-# -> SVector{2, Float64}(691875.632, 6098907.825)
+trans(12, 55)
+# -> (691875.632137542, 6.098907825129169e6)
 
 # using `inv` we can reverse the direction, `compose` can combine two transformations in one
-inv(trans)([691875.632, 6098907.825]) ≈ [12, 55]
+inv(trans)(691875.632137542, 6.098907825129169e6) == (12, 55)
 ```
 
 Note that, as described in https://proj.org/resource_files.html, PROJ has the capability

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -21,7 +21,7 @@ function rewrite(ex::Expr)
 
         # make certain function arguments optional
         if fname === :proj_coord
-            fargs′ = [kw(:x, 0.0), kw(:y, 0.0), kw(:z, 0.0), kw(:t, Inf)]
+            fargs′ = [:x, :y, kw(:z, 0.0), kw(:t, Inf)]
         elseif fname in (:proj_create_crs_to_crs, :proj_create_crs_to_crs_from_pj)
             fargs′[3] = kw(:area, :C_NULL)
         elseif fname === :proj_create_from_wkt

--- a/src/Proj.jl
+++ b/src/Proj.jl
@@ -3,6 +3,7 @@ module Proj
 using PROJ_jll
 using CEnum
 using CoordinateTransformations
+using NetworkOptions: ca_roots
 
 export PROJ_jll
 export PJ_DIRECTION, PJ_FWD, PJ_IDENT, PJ_INV
@@ -122,6 +123,12 @@ function __init__()
     # register custom error handler
     funcptr = @cfunction(log_func, Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Cstring))
     proj_log_func(C_NULL, funcptr)
+
+    # set path to CA certificates
+    ca_path = ca_roots()
+    if ca_path !== nothing
+        proj_context_set_ca_bundle_path(ca_path)
+    end
 
     # point to the location of the provided shared resources
     PROJ_LIB[] = joinpath(PROJ_jll.artifact_dir, "share", "proj")

--- a/src/libproj.jl
+++ b/src/libproj.jl
@@ -539,11 +539,11 @@ function proj_trans_bounds(
 end
 
 """
-    proj_coord(x = 0.0, y = 0.0, z = 0.0, t = Inf)
+    proj_coord(x, y, z = 0.0, t = Inf)
 
 Doxygen\\_Suppress
 """
-function proj_coord(x = 0.0, y = 0.0, z = 0.0, t = Inf)
+function proj_coord(x, y, z = 0.0, t = Inf)
     @ccall libproj.proj_coord(x::Cdouble, y::Cdouble, z::Cdouble, t::Cdouble)::Coord
 end
 

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,0 +1,38 @@
+using Proj
+using BenchmarkTools
+using StaticArrays
+
+const ctrans = Proj.Transformation("EPSG:4326", "EPSG:28992", always_xy = true)
+
+function timer(p)
+    tot = 0.0
+    for _ = 1:10_000
+        tot += sum(ctrans(p))
+    end
+    tot
+end
+
+function timer(x, y)
+    tot = 0.0
+    for _ = 1:10_000
+        tot += sum(ctrans(x, y))
+    end
+    tot
+end
+
+# test different input types
+svector = SA[5.39, 52.16]
+vector = [5.39, 52.16]
+tupl = (5.39, 52.16)
+x, y = 5.39, 52.16
+
+# timed using Julia 1.8.0-beta3
+@btime Proj.Coord($svector)  # 2.900 ns (0 allocations: 0 bytes)
+@btime Proj.Coord($vector)   # 3.700 ns (0 allocations: 0 bytes)
+@btime Proj.Coord($tupl)     # 2.600 ns (0 allocations: 0 bytes)
+@btime Proj.Coord($x, $y)    # 2.800 ns (0 allocations: 0 bytes)
+
+@btime timer($svector)       # 9.899 ms (0 allocations: 0 bytes)
+@btime timer($vector)        # 9.899 ms (0 allocations: 0 bytes)
+@btime timer($tupl)          # 9.908 ms (0 allocations: 0 bytes)
+@btime timer($x, $y)         # 9.977 ms (0 allocations: 0 bytes)

--- a/test/proj6api.jl
+++ b/test/proj6api.jl
@@ -337,7 +337,7 @@ end
     @test Proj.network_enabled()
     trans_z = Proj.Transformation("EPSG:4326+5773", "EPSG:7856+5711", always_xy = true)
     z = trans_z((151, -33, 5))[3]
-    @test trans_z((151, -33, 5))[3] ≈ 5.280603319143665
+    @test z ≈ 5.280603319143665
 
     # 0 args turns it on as well
     Proj.enable_network!(false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,11 @@
 using Proj
 using Test
-using GeometryBasics: Point
+using StaticArrays: SA
+
+# Base.isapprox doesn't work on tuples
+is_approx(a, b) = all(isapprox(c[1], c[2]) for c in zip(a, b))
 
 @testset "Proj" begin
-
     include("proj6api.jl")
     include("applications.jl")
 


### PR DESCRIPTION
Change `Coord` from being a `SVector{4, Float64}` alias to a struct implemented here. This struct is now mostly internal, since tuples are always returned from transformations. Length of the output tuple still depends on the input length. SVectors still work as input coordinates, just like tuples, vectors, and multiple arguments `f(x, y)`.

I included a benchmark here that shows that performance is good:
https://github.com/JuliaGeo/Proj4.jl/blob/a2e71c159a5892b0986e1b933fe0ff405ce940a2/test/benchmark.jl

This is the same benchmark as used here: https://github.com/JuliaGeo/Proj4.jl/pull/51#issuecomment-864467491. For types like SVector or tuples the return type (tuple length) can be inferred precisely, for Vector it infers `Union{NTuple{2,Float64},NTuple{3,Float64},NTuple{4,Float64}}` which is as good as we can expect.

This is on top of #57, but since it changes the return type of transformations I wanted to put it up separately for review. I think after this #57 would be ready for release, I was thinking to make it Proj.jl v1, such that we can actually start using the minor version number for features.